### PR TITLE
update deprecated boost url

### DIFF
--- a/pl.nieto.fityk.yaml
+++ b/pl.nieto.fityk.yaml
@@ -43,7 +43,7 @@ modules:
       - ./b2 install -j ${FLATPAK_BUILDER_N_JOBS}
     sources:
       - type: archive
-        url: https://boostorg.jfrog.io/artifactory/main/release/1.86.0/source/boost_1_86_0.tar.bz2
+        url: https://archives.boost.io/release/1.86.0/source/boost_1_86_0.tar.bz2
         sha256: 1bed88e40401b2cb7a1f76d4bab499e352fa4d0c5f31c0dbae64e24d34d7513b
     cleanup:
       - /include/boost


### PR DESCRIPTION


Download repository url has moved

refer: https://lists.boost.org/Archives/boost/2024/05/256914.php
